### PR TITLE
Fix packet registration for dedicated servers

### DIFF
--- a/src/main/java/dev/o7moon/openboatutils/ClientboundPackets.java
+++ b/src/main/java/dev/o7moon/openboatutils/ClientboundPackets.java
@@ -38,6 +38,12 @@ public enum ClientboundPackets {
     EXCLUSIVE_MODE_SERIES,
     SET_PER_BLOCK;
 
+    public static void registerCodecs() {
+        //? >=1.21 {
+        /*PayloadTypeRegistry.playS2C().register(OpenBoatUtils.BytePayload.ID, OpenBoatUtils.BytePayload.CODEC);*/
+        //? }
+    }
+
     public static void registerHandlers(){
         //? <=1.20.1 {
         ClientPlayNetworking.registerGlobalReceiver(OpenBoatUtils.settingsChannel, (client, handler, buf, responseSender) -> {
@@ -45,8 +51,7 @@ public enum ClientboundPackets {
         });
         //?}
         //? >=1.21 {
-        /*PayloadTypeRegistry.playS2C().register(OpenBoatUtils.BytePayload.ID, OpenBoatUtils.BytePayload.CODEC);
-        ClientPlayNetworking.registerGlobalReceiver(OpenBoatUtils.BytePayload.ID, ((payload, context) ->
+        /*ClientPlayNetworking.registerGlobalReceiver(OpenBoatUtils.BytePayload.ID, ((payload, context) ->
                 context.client().execute(() ->
                     handlePacket(new PacketByteBuf(Unpooled.wrappedBuffer(payload.data()))) )));
         *///?}

--- a/src/main/java/dev/o7moon/openboatutils/OpenBoatUtils.java
+++ b/src/main/java/dev/o7moon/openboatutils/OpenBoatUtils.java
@@ -34,6 +34,9 @@ public class OpenBoatUtils implements ModInitializer {
 
     @Override
     public void onInitialize() {
+        ClientboundPackets.registerCodecs();
+        ServerboundPackets.registerCodecs();
+
         ServerboundPackets.registerHandlers();
 
         SingleplayerCommands.registerCommands();

--- a/src/main/java/dev/o7moon/openboatutils/ServerboundPackets.java
+++ b/src/main/java/dev/o7moon/openboatutils/ServerboundPackets.java
@@ -8,6 +8,12 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 public enum ServerboundPackets {
     VERSION;
 
+    public static void registerCodecs() {
+        //? >=1.21 {
+        /*PayloadTypeRegistry.playC2S().register(OpenBoatUtils.BytePayload.ID, OpenBoatUtils.BytePayload.CODEC);*/
+        //? }
+    }
+
     public static void registerHandlers(){
         //? <=1.20.1 {
         ServerPlayNetworking.registerGlobalReceiver(OpenBoatUtils.settingsChannel, (server, player, handler, buf, responseSender) -> {
@@ -15,8 +21,7 @@ public enum ServerboundPackets {
         });
         //?}
         //? >=1.21 {
-        /*PayloadTypeRegistry.playC2S().register(OpenBoatUtils.BytePayload.ID, OpenBoatUtils.BytePayload.CODEC);
-        ServerPlayNetworking.registerGlobalReceiver(OpenBoatUtils.BytePayload.ID, ((payload, context) ->
+        /*ServerPlayNetworking.registerGlobalReceiver(OpenBoatUtils.BytePayload.ID, ((payload, context) ->
                 context.server().execute(() ->
                     handlePacket(payload.data()) )));
         *///?}


### PR DESCRIPTION
This PR ensures that the clientbound codec is registered even on dedicated servers

The way the 1.20.4 networking API is supposed to be used is the stream codecs should be registered on both the client & server (after all, if it isn't registered the server can't send it)

Currently, the mod only works on an Integrated Server by coincidence

I understand that the intent of the mod is for it to only work in Singleplayer, but a friend requested this change and I figured it was simple enough that other people might benefit from the fix