### PR TITLE
Prevent boat from lagging  in singleplayer while ascending a staircase

### DIFF
--- a/src/main/java/dev/o7moon/openboatutils/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/dev/o7moon/openboatutils/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,9 +1,12 @@
 package dev.o7moon.openboatutils.mixin;
 
 import net.minecraft.server.network.ServerPlayNetworkHandler;
+import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerPlayNetworkHandler.class)
@@ -12,4 +15,14 @@ public class ServerPlayNetworkHandlerMixin {
     private static void isMovementInvalid(CallbackInfoReturnable<Boolean> cir) {
         cir.setReturnValue(false);// !!! this disables the movement anti-cheat, but is necessary for stepping to work in singleplayer
     }
+
+    // Force the flag that triggers moved wrongly to false
+    @ModifyVariable(method = "onVehicleMove", at = @At("STORE"), ordinal = 2)
+    private boolean onVehicleMove_WronglyFlag(boolean original) {
+        return false;
+    }
+
+    // Skip the "moved "wrongly" warn. also skips "moved too quickly"
+    @Redirect(method = "onVehicleMove", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;[Ljava/lang/Object;)V"))
+    private void preventMovedWronglyLog(Logger instance, String s, Object[] objects) {}
 }


### PR DESCRIPTION
In single player, boats still sometimes lag backward while ascending a staircase, filling logs with "Moved Wrongly"

This PR forces the relevant flag set during "moved wrongly" to false, preventing it from moving the player back. Additionally, It hooks the warn call to prevent the logs being filled with "moved wrongly" and "moved too quickly"

As long as the mod runs within the integrated server, this shouldn't have any cheating consequences.
