### PR TITLE
add canStepWhileFalling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version_allowed_range=>=1.20.1 <=1.20.4
 yarn_mappings=1.20.1+build.10
 loader_version=0.15.11
 # Mod Properties
-mod_version=0.4.3_1.20.1-1.20.4
+mod_version=0.4.4_1.20.1-1.20.4
 maven_group=dev.o7moon
 archives_base_name=OpenBoatUtils
 # Dependencies

--- a/src/main/java/dev/o7moon/openboatutils/ClientboundPackets.java
+++ b/src/main/java/dev/o7moon/openboatutils/ClientboundPackets.java
@@ -37,7 +37,8 @@ public enum ClientboundPackets {
     MODE_SERIES,
     EXCLUSIVE_MODE_SERIES,
     SET_PER_BLOCK,
-    SET_COLLISION_MODE;
+    SET_COLLISION_MODE,
+    SET_STEP_WHILE_FALLING;
 
     public static void registerCodecs() {
         //? >=1.21 {
@@ -184,6 +185,10 @@ public enum ClientboundPackets {
                 case 27:
                     short cmode = buf.readShort();
                     OpenBoatUtils.setCollisionMode(CollisionMode.values()[cmode]);
+                    return;
+                case 28:
+                    enabled = buf.readBoolean();
+                    OpenBoatUtils.setCanStepWhileFalling(enabled);
                     return;
             }
         } catch (Exception E) {

--- a/src/main/java/dev/o7moon/openboatutils/Modes.java
+++ b/src/main/java/dev/o7moon/openboatutils/Modes.java
@@ -25,6 +25,8 @@ public enum Modes {
     DEFAULT_BLUE_ICE,//19
     NOCOL_BOATS_AND_PLAYERS,//20
     NOCOL_ALL_ENTITIES,//21
+    BA_JANKLESS,
+    BA_BLUE_JANKLESS
     ;
 
     public static void setMode(Modes mode) {
@@ -162,6 +164,20 @@ public enum Modes {
                 return;
             case NOCOL_ALL_ENTITIES:
                 OpenBoatUtils.setCollisionMode(CollisionMode.NO_ENTITIES);
+                return;
+            case BA_JANKLESS:
+                OpenBoatUtils.setCanStepWhileFalling(true);
+                OpenBoatUtils.setAirControl(true);
+                OpenBoatUtils.setBlockSlipperiness("minecraft:air", 0.98f);
+                OpenBoatUtils.setStepSize(1.25f);
+                OpenBoatUtils.setWaterElevation(true);
+                return;
+            case BA_BLUE_JANKLESS:
+                OpenBoatUtils.setCanStepWhileFalling(true);
+                OpenBoatUtils.setAirControl(true);
+                OpenBoatUtils.setBlockSlipperiness("minecraft:air", 0.989f);
+                OpenBoatUtils.setStepSize(1.25f);
+                OpenBoatUtils.setWaterElevation(true);
                 return;
         }
     }

--- a/src/main/java/dev/o7moon/openboatutils/Modes.java
+++ b/src/main/java/dev/o7moon/openboatutils/Modes.java
@@ -1,7 +1,5 @@
 package dev.o7moon.openboatutils;
 
-import java.util.ArrayList;
-
 public enum Modes {
     BROKEN_SLIME_RALLY,//0
     BROKEN_SLIME_RALLY_BLUE,//1

--- a/src/main/java/dev/o7moon/openboatutils/OpenBoatUtils.java
+++ b/src/main/java/dev/o7moon/openboatutils/OpenBoatUtils.java
@@ -44,7 +44,7 @@ public class OpenBoatUtils implements ModInitializer {
 
     public static final Logger LOG = LoggerFactory.getLogger("OpenBoatUtils");
 
-    public static final int VERSION = 10;
+    public static final int VERSION = 11;
 
     public static final Identifier settingsChannel = Identifier.of("openboatutils","settings");
 
@@ -68,6 +68,7 @@ public class OpenBoatUtils implements ModInitializer {
     public static boolean waterJumping = false;
     public static float swimForce = 0.0f;
     public static CollisionMode collision = CollisionMode.VANILLA;
+    public static boolean canStepWhileFalling = false; // Setting to true fixes "boatutils jank"
 
     public static HashMap<String, Float> vanillaSlipperinessMap;
 
@@ -174,6 +175,7 @@ public class OpenBoatUtils implements ModInitializer {
         slipperinessMap = new HashMap<>(getVanillaSlipperinessMap());
         perBlockSettings = new HashMap<>();
         collision = CollisionMode.VANILLA;
+        canStepWhileFalling = false;
     }
 
     public static void setStepSize(float stepsize){
@@ -396,5 +398,13 @@ public class OpenBoatUtils implements ModInitializer {
 
     public static CollisionMode getCollisionMode() {
         return collision;
+    }
+
+    public static boolean canStepWhileFalling() {
+        return canStepWhileFalling;
+    }
+
+    public static void setCanStepWhileFalling(boolean canStepWhileFalling) {
+        OpenBoatUtils.canStepWhileFalling = canStepWhileFalling;
     }
 }

--- a/src/main/java/dev/o7moon/openboatutils/SingleplayerCommands.java
+++ b/src/main/java/dev/o7moon/openboatutils/SingleplayerCommands.java
@@ -424,6 +424,18 @@ public class SingleplayerCommands {
                             })
                     )
             );
+
+            dispatcher.register(
+                    literal("stepwhilefalling").then(argument("enabled", BoolArgumentType.bool()).executes(ctx -> {
+                        ServerPlayerEntity player = ctx.getSource().getPlayer();
+                        if (player == null) return 0;
+                        PacketByteBuf packet = PacketByteBufs.create();
+                        packet.writeShort(ClientboundPackets.SET_STEP_WHILE_FALLING.ordinal());
+                        packet.writeBoolean(BoolArgumentType.getBool(ctx, "enabled"));
+                        OpenBoatUtils.sendPacketS2C(player, packet);
+                        return 1;
+                    }))
+            );
         });
     }
 }

--- a/src/main/java/dev/o7moon/openboatutils/mixin/EntityMixin.java
+++ b/src/main/java/dev/o7moon/openboatutils/mixin/EntityMixin.java
@@ -1,11 +1,13 @@
 package dev.o7moon.openboatutils.mixin;
 
 import dev.o7moon.openboatutils.GetStepHeight;
+import dev.o7moon.openboatutils.OpenBoatUtils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.vehicle.BoatEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
@@ -17,5 +19,16 @@ public abstract class EntityMixin {
             cir.setReturnValue(step.getStepHeight());
             cir.cancel();
         }
+    }
+
+    @ModifyVariable(method = "adjustMovementForCollisions(Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/Vec3d;", at = @At("STORE"), ordinal = 3)
+    private boolean hookStepHeightOnGroundCheck(boolean original) {
+        if ((Object) this instanceof BoatEntity) {
+            if (OpenBoatUtils.canStepWhileFalling()) {
+                return true;
+            }
+        }
+
+        return original;
     }
 }

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version_allowed_range=>=1.21 <=1.21.1
 yarn_mappings=1.21+build.8
 loader_version=0.15.11
 # Mod Properties
-mod_version=0.4.3_1.21
+mod_version=0.4.4_1.21
 maven_group=dev.o7moon
 archives_base_name=OpenBoatUtils
 # Dependencies


### PR DESCRIPTION
provides the ability for a boat to step up a block while falling, aimed to fix "boatutils jank" without increasing gravity to high values
works well, but at high speeds on steeper surfaces wall priority still causes the boat to get bumped

<https://youtu.be/FHSJ79AYbdg>

*only tested in 1.21.1 as of now*