### PR TITLE
[extra-versions] fix: explicit refmap

### DIFF
--- a/src/main/resources/openboatutils.mixins.json5
+++ b/src/main/resources/openboatutils.mixins.json5
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "package": "dev.o7moon.openboatutils.mixin",
   "compatibilityLevel": "JAVA_17",
+  "refmap": "OpenBoatUtils-refmap.json",
   "mixins": [
     "ServerPlayNetworkHandlerMixin"
   ],


### PR DESCRIPTION
Tested some of the `extra-versions` builds for the first time out of dev, turns out the refmap fails to load. Specifying it explicitly in fabric.mod.json fixes this, additionally doesn't break any of the older versions.