### PR TITLE
[extra-versions] fix: interpolation should ignore OpenBoatUtils.enabled

### DIFF
--- a/versions/1.21.5/src/main/java/dev/o7moon/openboatutils/mixin/AbstractBoatMixin.java
+++ b/versions/1.21.5/src/main/java/dev/o7moon/openboatutils/mixin/AbstractBoatMixin.java
@@ -189,7 +189,7 @@ public abstract class AbstractBoatMixin implements GetStepHeight {
             at = @At("HEAD")
     )
     private void hookPositionInterpolator(CallbackInfo ci) {
-        if (OpenBoatUtils.enabled && OpenBoatUtils.interpolationCompat) {
+        if (OpenBoatUtils.interpolationCompat) {
             interpolator.setLerpDuration(10);
             return;
         }

--- a/versions/1.21.6/src/main/java/dev/o7moon/openboatutils/mixin/AbstractBoatMixin.java
+++ b/versions/1.21.6/src/main/java/dev/o7moon/openboatutils/mixin/AbstractBoatMixin.java
@@ -189,7 +189,7 @@ public abstract class AbstractBoatMixin implements GetStepHeight {
             at = @At("HEAD")
     )
     private void hookPositionInterpolator(CallbackInfo ci) {
-        if (OpenBoatUtils.enabled && OpenBoatUtils.interpolationCompat) {
+        if (OpenBoatUtils.interpolationCompat) {
             interpolator.setLerpDuration(10);
             return;
         }

--- a/versions/1.21.9/src/main/java/dev/o7moon/openboatutils/mixin/AbstractBoatMixin.java
+++ b/versions/1.21.9/src/main/java/dev/o7moon/openboatutils/mixin/AbstractBoatMixin.java
@@ -189,7 +189,7 @@ public abstract class AbstractBoatMixin implements GetStepHeight {
             at = @At("HEAD")
     )
     private void hookPositionInterpolator(CallbackInfo ci) {
-        if (OpenBoatUtils.enabled && OpenBoatUtils.interpolationCompat) {
+        if (OpenBoatUtils.interpolationCompat) {
             interpolator.setLerpDuration(10);
             return;
         }


### PR DESCRIPTION
Originally checked for `OpenBoatUtils.enabled` before enabling the interpolation fix, which I shouldn't have.

As of this commit, it has been tested that the interpolation fix in future versions is consistent with 1.21.1